### PR TITLE
Refs [TASK] [36140] Xử lý sự kiện menu app

### DIFF
--- a/app/src/main/java/com/sun/hero_01/ui/MainActivity.kt
+++ b/app/src/main/java/com/sun/hero_01/ui/MainActivity.kt
@@ -3,6 +3,8 @@ package com.sun.hero_01.ui
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.sun.hero_01.R
@@ -19,6 +21,25 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         initView()
         initEvent()
+    }
+
+    override fun onBackPressed() {
+        if (supportFragmentManager.backStackEntryCount > 0) {
+            val fragment: Fragment? =
+                supportFragmentManager.findFragmentById(R.id.frameContainer)
+            when (fragment) {
+                is ChampionFragment, is ClassFragment, is FavoriteFragment -> {
+                    showAlertDialog(getString(R.string.notify_exit_app)){
+                        finish()
+                    }
+                }
+                else -> {
+                    super.onBackPressed()
+                }
+            }
+        } else {
+            super.onBackPressed()
+        }
     }
 
     private fun initView() {
@@ -48,6 +69,9 @@ class MainActivity : AppCompatActivity() {
                 else -> false
             }
         }
+        navigationBottom.setOnNavigationItemReselectedListener {
+            Toast.makeText(this, getString(R.string.notify_reselect_item), Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun loadFragment(fragment: Fragment) {
@@ -60,6 +84,16 @@ class MainActivity : AppCompatActivity() {
 
     fun setBottomNavigationVisibility(visibility: Int) {
         navigationBottom.visibility = visibility
+    }
+
+    private fun showAlertDialog(msg: String, onConfirm: () -> Unit) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.app_name_toolbar)
+            .setMessage(msg)
+            .setNegativeButton(android.R.string.no, null)
+            .setPositiveButton(android.R.string.yes) { _, _ -> onConfirm() }
+            .create()
+            .show()
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="menu_class">class</string>
     <string name="menu_favorite">favorite</string>
     <string name="app_name_toolbar">HERO LOL</string>
+    <string name="notify_reselect_item">You have already selected</string>
+    <string name="notify_exit_app">Exit app?</string>
 </resources>


### PR DESCRIPTION
## Related Tickets
- [#Task 36140: Xử lý sự kiện menu app](https://edu-redmine.sun-asterisk.vn/issues/36140)
## WHAT
- Xử lý sự kiện click và back menu app
## Evidence (Screenshot or Video)

## Review Checklist

Category | View Point | Description | Self review | Reviewer2 (name)
--- | --- | --- | --- | ---
Conventions | Sun* coding conventions | https://github.com/framgia/coding-standards/tree/master/eng/android |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Conventions | Kotlin coding conventions | https://kotlinlang.org/docs/coding-conventions.html |<li>- [ ] yes</li>|<li>- [ ] yes</li>  
Redmine | Sun* Redmine working process  | https://github.com/framgia/Training-Guideline/blob/master/WorkingProcess/redmine/redmine.md |<li>- [ ] yes</li>|<li>- [ ] yes</li>  

## Notes (Optional)
*(Impacted Areas in Application(List features, api, models or services that this PR will affect))*

*(List gem, library third party add new)*

*(Other notes)*
